### PR TITLE
check ng-dblclick event for target

### DIFF
--- a/src/angular-gridster-factory-draggable.js
+++ b/src/angular-gridster-factory-draggable.js
@@ -34,7 +34,7 @@ angular.module('gridster')
 				}
 
 				// exit, if the target has it's own click event
-				if (angular.element(e.target).attr('onclick') || angular.element(e.target).attr('ng-click')) {
+				if (angular.element(e.target).attr('onclick') || angular.element(e.target).attr('ng-click') || angular.element(e.target).attr('ng-dblclick')) {
 					return false;
 				}
 


### PR DESCRIPTION
Except onclick and ng-click, the ng-dblclick should also be checked and return false before start drag. 
Right now, in x1-ui-ng-workspaces, the title is bind to ng-dblclick event. If we don't check this event, gridster will think we are going to start drag if we dblclick the title. Because dblclick is comprised with click events. It prevent we are able to edit the title.